### PR TITLE
Handle exceptions for adding request body audit log if rest request is invalid

### DIFF
--- a/src/main/java/org/opensearch/security/auditlog/impl/AuditMessage.java
+++ b/src/main/java/org/opensearch/security/auditlog/impl/AuditMessage.java
@@ -417,7 +417,7 @@ public final class AuditMessage {
                     } else {
                         auditInfo.put(REQUEST_BODY, requestBody);
                     }
-                } catch (IOException e) {
+                } catch (Exception e) {
                     auditInfo.put(REQUEST_BODY, "ERROR: Unable to generate request body");
                 }
             }

--- a/src/test/java/org/opensearch/security/auditlog/impl/AuditMessageTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/impl/AuditMessageTest.java
@@ -26,9 +26,16 @@ import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.http.HttpChannel;
+import org.opensearch.http.HttpRequest;
+import org.opensearch.rest.RestRequest;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.auditlog.config.AuditConfig;
+import org.opensearch.security.filter.SecurityRequest;
+import org.opensearch.security.filter.SecurityRequestFactory;
 import org.opensearch.security.securityconf.impl.CType;
 
 import static org.junit.Assert.assertEquals;
@@ -154,5 +161,42 @@ public class AuditMessageTest {
         BytesReference ref = BytesReference.fromByteBuffers(byteBuffers);
         message.addSecurityConfigTupleToRequestBody(new Tuple<>(XContentType.JSON, ref), internalUsersDocId);
         assertEquals("Hash in tuple is __HASH__", message.getAsMap().get(AuditMessage.REQUEST_BODY));
+    }
+
+    @Test
+    public void testRequestBodyLoggingWithInvalidSourceOrContentTypeParam() {
+        when(auditConfig.getFilter().shouldLogRequestBody()).thenReturn(true);
+
+        HttpRequest httpRequest = mock(HttpRequest.class);
+
+        // No content or Source paramater
+        when(httpRequest.uri()).thenReturn("");
+        when(httpRequest.content()).thenReturn(new BytesArray(new byte[0]));
+
+        RestRequest restRequest = RestRequest.request(mock(NamedXContentRegistry.class), httpRequest, mock(HttpChannel.class));
+        SecurityRequest request = SecurityRequestFactory.from(restRequest);
+
+        message.addRestRequestInfo(request, auditConfig.getFilter());
+        assertNull(message.getAsMap().get(AuditMessage.REQUEST_BODY));
+
+        // No source parameter, content present but Invalid content-type header
+        when(httpRequest.uri()).thenReturn("");
+        when(httpRequest.content()).thenReturn(new BytesArray(new byte[1]));
+
+        restRequest = RestRequest.request(mock(NamedXContentRegistry.class), httpRequest, mock(HttpChannel.class));
+        request = SecurityRequestFactory.from(restRequest);
+
+        message.addRestRequestInfo(request, auditConfig.getFilter());
+        assertEquals("ERROR: Unable to generate request body", message.getAsMap().get(AuditMessage.REQUEST_BODY));
+
+        // No content, source parameter present but Invalid source-content-type parameter
+        when(httpRequest.uri()).thenReturn("/aaaa?source=request_body");
+        when(httpRequest.content()).thenReturn(new BytesArray(new byte[0]));
+
+        restRequest = RestRequest.request(mock(NamedXContentRegistry.class), httpRequest, mock(HttpChannel.class));
+        request = SecurityRequestFactory.from(restRequest);
+
+        message.addRestRequestInfo(request, auditConfig.getFilter());
+        assertEquals("ERROR: Unable to generate request body", message.getAsMap().get(AuditMessage.REQUEST_BODY));
     }
 }


### PR DESCRIPTION
Resolves #1849

### Description
This change fixes the bug https://github.com/opensearch-project/security/issues/1849. This change ensures audit logging logs a failed request if request body fails to match content-type header or required parameters.
* Category: Bug fix
* Why these changes are required?
This change is required to be consistent with user provided configuration of audit logging request body even for failed requests
* What is the old behavior before changes and new behavior after changes?
Before this change, an invalid request (with invalid content or source type parameters) did not get audit_request_body even if request body audit logging is enabled by user because of improper exception handling. After this change, audit_request_body will be generated

### Issues Resolved
https://github.com/opensearch-project/security/issues/1849

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Unit tested

### Check List
- [X] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
